### PR TITLE
npm: enable building addons to target UWP

### DIFF
--- a/deps/npm/bin/npm-cli.js
+++ b/deps/npm/bin/npm-cli.js
@@ -25,6 +25,8 @@
   var npm = require('../lib/npm.js')
   var npmconf = require('../lib/config/core.js')
   var errorHandler = require('../lib/utils/error-handler.js')
+  var parseJSON = require('../lib/utils/parse-json.js')
+  var fs = require('fs')
 
   var configDefs = npmconf.defs
   var shorthands = configDefs.shorthands
@@ -36,7 +38,7 @@
   if (path.basename(process.argv[1]).slice(-1) === 'g') {
     process.argv.splice(1, 1, 'npm', '-g')
   }
-
+  
   log.verbose('cli', process.argv)
 
   var conf = nopt(types, shorthands)
@@ -63,6 +65,24 @@
   if (conf.usage && npm.command !== 'help') {
     npm.argv.unshift(npm.command)
     npm.command = 'help'
+  }
+  
+  // check package.json to see if the package to install
+  // needs uwp and target architecture options.
+  if('install' == npm.command) {
+	console.log('hello');
+    var localJsonPath = path.join(process.cwd(), '\package.json');
+    if(fs.existsSync(localJsonPath)) {
+      var j = parseJSON(fs.readFileSync(localJsonPath + ''));
+      
+      if(j.target_arch) {
+      	process.argv.push('--target_arch=' + j.target_arch);
+      }
+      
+      if(j.platform == 'uwp') {
+      	process.argv.push('--node_uwp_dll');
+      } 
+    }
   }
 
   // now actually fire up npm and run the command.

--- a/deps/npm/bin/npm-cli.js
+++ b/deps/npm/bin/npm-cli.js
@@ -70,7 +70,6 @@
   // check package.json to see if the package to install
   // needs uwp and target architecture options.
   if('install' == npm.command) {
-	console.log('hello');
     var localJsonPath = path.join(process.cwd(), '\package.json');
     if(fs.existsSync(localJsonPath)) {
       var j = parseJSON(fs.readFileSync(localJsonPath + ''));

--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'node_lib_path%': '$(ProgramFiles)\NodejsUwp\$(PlatformTarget)',
+  },
   'target_defaults': {
     'type': 'loadable_module',
     'win_delay_load_hook': 'true',
@@ -94,7 +97,7 @@
               '-l"<(node_root_dir)/$(ConfigurationName)/<(node_lib_file)"'
             ],
           }],
-          ['node_uwp_dll=="true"', {
+          ['node_uwp_dll=="true"', {  
             'include_dirs': [
               '<(node_root_dir)/deps/logger/include',
             ],
@@ -105,7 +108,28 @@
             'msvs_enable_winrt': 1,
             'msvs_application_type_revision': '10.0',
             'msvs_windows_target_platform_version':'v10.0',
-            'libraries': [ '-l"<(node_lib_file)"' ],
+            'msvs_settings': {
+              'VCLinkerTool': {
+                'IgnoreDefaultLibraryNames' : ['kernel32.lib','advapi32.lib', 'ole32.lib' ],
+                'AdditionalLibraryDirectories' : [ '<(node_lib_path)' ],
+                'conditions': [
+                [ 'target_arch=="ia32"', {
+                  'AdditionalLibraryDirectories' : [ '$(VCInstallDir)lib\onecore;$(WindowsSDK_LibraryPath_x86);$(UniversalCRT_LibraryPath_x86)' ],
+                } ],
+                [ 'target_arch=="x64"', {
+                  'AdditionalLibraryDirectories' : [ '$(VCInstallDir)lib\onecore\\amd64;$(WindowsSDK_LibraryPath_x64);$(UniversalCRT_LibraryPath_x64)' ],
+                } ],
+                [ 'target_arch=="arm"', {
+                  'AdditionalLibraryDirectories' : [ '$(VCInstallDir)lib\onecore\\arm;$(WindowsSDK_LibraryPath_arm);$(UniversalCRT_LibraryPath_arm)' ],
+                } ],
+              ],
+              },
+              'VCCLCompilerTool': {
+                'AdditionalUsingDirectories': [ '$(VCInstallDir)vcpackages;$(WindowsSdkDir)UnionMetadata;%(AdditionalUsingDirectories)' ],
+                'CompileAsWinRT': 'true',
+              }
+            },
+            'libraries': [ '-l"<(node_lib_file)"', '-lonecore.lib' ],
             'configurations': {
               'Release': {
                 'msvs_settings': {


### PR DESCRIPTION
This change allows building node (native) addons that work in a UWP application. To build for UWP the command is:
`npm install <package name> --target_arch=<arch> --node_uwp_dll`

To install using package.json, the following properties need to be set:
* target_arch (values allowed: 'arm', 'x86', 'x64')
* platform (value expected: 'uwp')