### PR TITLE
Fixing msi and npm issues

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/configure.js
+++ b/deps/npm/node_modules/node-gyp/lib/configure.js
@@ -32,6 +32,7 @@ function configure (gyp, argv, callback) {
     , configs = []
     , nodeDir
     , release = processRelease(argv, gyp, process.version, process.release)
+    , nodeUseSdk
 
   findPython(python, function (err, found) {
     if (err) {
@@ -55,6 +56,23 @@ function configure (gyp, argv, callback) {
       createBuildDir()
 
     } else {
+      // try to use addon sdk if applicable
+      if (win) {
+        try {
+          var sdkDir = path.resolve(path.dirname(process.execPath), "sdk")
+          if (fs.statSync(sdkDir)) {
+            nodeDir = sdkDir
+            nodeUseSdk = true
+          }
+        } catch (e) {
+        }
+
+        if (nodeUseSdk) {
+          log.verbose('get node dir', 'compiling against installed dev files: %s', nodeDir)
+          return createBuildDir()
+        }
+      }
+
       // if no --nodedir specified, ensure node dependencies are installed
       if ('v' + release.version !== process.version) {
         // if --target was given, then determine a target version to compile for
@@ -130,8 +148,8 @@ function configure (gyp, argv, callback) {
     // set the node development directory
     variables.nodedir = nodeDir
 
-    // don't copy dev libraries with nodedir option
-    variables.copy_dev_lib = !gyp.opts.nodedir
+    // don't copy dev libraries with nodedir option or using sdk
+    variables.copy_dev_lib = !gyp.opts.nodedir && !nodeUseSdk
 
     // disable -T "thin" static archives by default
     variables.standalone_static_library = gyp.opts.thin ? 0 : 1
@@ -273,6 +291,7 @@ function configure (gyp, argv, callback) {
       argv.push('-Dnode_lib_file=' + release.name + '.lib')
       argv.push('-Dmodule_root_dir=' + process.cwd())
       argv.push('-Dnode_engine=' + (gyp.opts.node_engine || process.jsEngine || 'v8'))
+      argv.push('-Dnode_use_sdk=' + nodeUseSdk)
       argv.push('--depth=.')
       argv.push('--no-parallel')
 

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -6,39 +6,35 @@
     <ProductVersion>3.5</ProductVersion>
     <ProjectGuid>{1d808ff0-b5a9-4be9-859d-b334b6f48be2}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>node-v$(FullVersion)-$(Platform)</OutputName>
+    <OutputName>$(NodeMsiOutput)</OutputName>
     <OutputType>Package</OutputType>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <NodeVersion Condition=" '$(NodeVersion)' == '' ">0.0.0.0</NodeVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup>
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>SdkTargetArch=$(SdkTargetArch);NodeEngine=$(NodeEngine);NodeName=$(NodeName);NodeShortName=$(NodeShortName);NodeUseSdk=$(NodeUseSdk);ProductFullVersion=$(NodeFullVersion);ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NodeSdkSourceDir=..\..\..\$(Configuration)\sdk;NpmSourceDir=..\..\..\deps\npm</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>..\..\..\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);Debug</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <OutputPath>..\..\..\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
-    <Cultures>en-US</Cultures>
+  <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
+    <DefineConstants>$(DefineConstants);ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <OutputPath>..\..\..\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+  <PropertyGroup Condition=" '$(Platform)' == 'x64' ">
+    <DefineConstants>$(DefineConstants);ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="product.wxs" />
+    <Compile Include="..\..\..\sdk.wxs" Condition=" '$(NodeUseSdk)' != '' ">
+      <Link>sdk.wxs</Link>
+    </Compile>
     <Compile Include="..\..\..\npm.wxs">
       <Link>npm.wxs</Link>
     </Compile>
@@ -54,11 +50,7 @@
     </WixExtension>
   </ItemGroup>
   <ItemGroup>
-    <!--
-    <EmbeddedResource Include="i18n\de-de.wxl" />
-    <EmbeddedResource Include="i18n\it-it.wxl" />
-    <EmbeddedResource Include="i18n\zh-cn.wxl" />
-    -->
+    <!-- <EmbeddedResource Include="i18n\de-de.wxl" /> -->
     <EmbeddedResource Include="i18n\en-us.wxl" />
   </ItemGroup>
   <ItemGroup>
@@ -73,6 +65,16 @@
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <Target Name="BeforeBuild">
+    <Exec Condition=" '$(NodeUseSdk)' != '' "
+          Command="robocopy $(SolutionDir)..\..\..  $(SolutionDir)..\..\..\$(Configuration)\sdk *.h *.inc common.gypi /XD debug release build icu core /S /NJH /NFL /NDL /NP
+if ERRORLEVEL 8 goto failed
+exit 0
+:failed
+echo Copy source header files failed
+exit 1"/>
+    <HeatDirectory Condition=" '$(NodeUseSdk)' != '' "
+                   ToolPath="$(WixToolPath)" Directory="..\..\..\$(Configuration)\sdk" PreprocessorVariable="var.NodeSdkSourceDir" DirectoryRefId="INSTALLDIR" ComponentGroupName="NodeSdkFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\sdk.wxs" RunAsSeparateProcess="true">
+    </HeatDirectory>
     <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\deps\npm" PreprocessorVariable="var.NpmSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="NpmSourceFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\npm.wxs" RunAsSeparateProcess="true">
     </HeatDirectory>
   </Target>
@@ -82,12 +84,8 @@
     <!--
     <PostBuildEvent>
       "$(WixToolPath)\torch.exe" -t language "$(TargetDir)en-US\$(TargetFileName)" "$(TargetDir)de-de\$(TargetFileName)" -out "$(TargetDir)transforms\de-de.mst"
-      "$(WixToolPath)\torch.exe" -t language "$(TargetDir)en-US\$(TargetFileName)" "$(TargetDir)it-it\$(TargetFileName)" -out "$(TargetDir)transforms\it-it.mst"
-      "$(WixToolPath)\torch.exe" -t language "$(TargetDir)en-US\$(TargetFileName)" "$(TargetDir)zh-cn\$(TargetFileName)" -out "$(TargetDir)transforms\zh-cn.mst"
       cscript.exe "$(WindowsSDK80Path)bin\$(Platform)\WiSubStg.vbs" "$(TargetDir)en-US\$(TargetFileName)" "$(TargetDir)transforms\de-de.mst" 1031
-      cscript.exe "$(WindowsSDK80Path)bin\$(Platform)\WiSubStg.vbs" "$(TargetDir)en-US\$(TargetFileName)" "$(TargetDir)transforms\it-it.mst" 1040
-      cscript.exe "$(WindowsSDK80Path)bin\$(Platform)\WiSubStg.vbs" "$(TargetDir)en-US\$(TargetFileName)" "$(TargetDir)transforms\zh-cn.mst" 2052
-      cscript.exe "$(WindowsSDK80Path)bin\$(Platform)\WiLangId.vbs" "$(TargetDir)en-US\$(TargetFileName)" Package 1031,1033,1040,2052
+      cscript.exe "$(WindowsSDK80Path)bin\$(Platform)\WiLangId.vbs" "$(TargetDir)en-US\$(TargetFileName)" Package 1033,1031
     </PostBuildEvent>
     -->
   </PropertyGroup>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -2,24 +2,38 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
-  <?define ProductName = "Node.js" ?>
-  <?define ProductDescription = "Node.js" ?>
+  <?define ProductName = "$(var.NodeName)" ?>
+  <?define ProductDescription = "$(var.NodeName)" ?>
   <?define ProductAuthor = "Node.js Foundation" ?>
 
-  <?define RegistryKeyPath = "SOFTWARE\Node.js" ?>
+  <?define RegistryKeyPath = "SOFTWARE\$(var.ProductName)" ?>
 
   <?define RepoDir="$(var.ProjectDir)..\..\..\" ?>
   <?define SourceDir="$(var.RepoDir)\$(var.Configuration)\" ?>
 
+  <?if $(var.NodeUseSdk) = "" ?>
+  <?define NodeExeSource = "$(var.SourceDir)\node.exe" ?>
+  <?else?>
+  <?define NodeExeSource = "$(var.SourceDir)\$(var.SdkTargetArch)\node.exe" ?>
+  <?endif?>
+
+  <?if $(var.NodeEngine) = "v8" ?>
+  <?define UpgradeCode = "47c07a3a-42ef-4213-a85d-8f5a59077c28" ?>
+  <?elseif $(var.NodeEngine) = "chakra" ?>
+  <?define UpgradeCode = "621ed213-8ca3-4d8e-9265-6066534d7796" ?>
+  <?elseif $(var.NodeEngine) = "chakracore" ?>
+  <?define UpgradeCode = "e1648eea-9548-4dc4-936f-e8fec1b1020e" ?>
+  <?endif?>
+
   <Product Id="*"
            Name="$(var.ProductName)"
            Language="!(loc.LocaleId)"
-           Version="$(var.ProductVersion)"
+           Version="$(var.ProductFullVersion)"
            Manufacturer="$(var.ProductAuthor)"
-           UpgradeCode="47c07a3a-42ef-4213-a85d-8f5a59077c28">
+           UpgradeCode="$(var.UpgradeCode)">
 
     <Package Languages="!(loc.LocaleId)"
-             InstallerVersion="200"
+             InstallerVersion="301"
              Compressed="yes"
              InstallScope="perMachine"/>
 
@@ -32,6 +46,7 @@
     <MajorUpgrade AllowSameVersionUpgrades="yes"
                   DowngradeErrorMessage="!(loc.MajorUpgrade_DowngradeErrorMessage)"/>
 
+    <?if $(var.NodeEngine) = "v8" ?>
     <Upgrade Id="1d60944c-b9ce-4a71-a7c0-0384eb884baa">
       <UpgradeVersion Maximum="1.0.0"
                       IncludeMaximum="no"
@@ -40,27 +55,17 @@
                       IncludeMinimum="yes"
                       Property="EARLY_IO_DETECTED" />
     </Upgrade>
+    <?elseif $(var.NodeEngine) = "chakra" ?>
+    <Upgrade Id="68be990c-51ab-4822-b6d1-8a95f1e62c1b">
+      <UpgradeVersion Maximum="1.0.0"
+                      IncludeMaximum="no"
+                      Property="NODE_0X_DETECTED" />
+    </Upgrade>
+    <?endif?>
 
     <Icon Id="NodeIcon" SourceFile="$(var.RepoDir)\src\res\node.ico"/>
     <Property Id="ARPPRODUCTICON" Value="NodeIcon"/>
-    <Property Id="ApplicationFolderName" Value="nodejs"/>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"/>
-
-    <Property Id="INSTALLDIR">
-      <RegistrySearch Id="InstallPathRegistry"
-                      Type="raw"
-                      Root="HKLM"
-                      Key="$(var.RegistryKeyPath)"
-                      Name="InstallPath"/>
-      <!-- Also need to search under HKCU to support upgrading from old
-           versions. If we wanted to disable backward compatibility, this
-           second search could be deleted. -->
-      <RegistrySearch Id="InstallPathRegistryCU"
-                      Type="raw"
-                      Root="HKCU"
-                      Key="$(var.RegistryKeyPath)"
-                      Name="InstallPath"/>
-    </Property>
+    <Property Id="ApplicationFolderName" Value="$(var.NodeShortName)"/>
 
     <Feature Id="NodeRuntime"
              Level="1"
@@ -73,6 +78,19 @@
       <ComponentRef Id="NodeStartMenu"/>
       <ComponentRef Id="AppData" />
       <ComponentGroupRef Id="Product.Generated"/>
+
+      <?if $(var.NodeEngine) = "chakracore" ?>
+      <ComponentRef Id="ChakraCoreDLL"/>
+      <?endif?>
+
+      <?if $(var.NodeUseSdk) != "" ?>
+      <Feature Id="NodeNativeAddonSDK"
+               Level="1"
+               Title="Node.js native addon module SDK"
+               Description="Installs headers and libs for building Node.js native addon modules.">
+        <ComponentGroupRef Id="NodeSdkFiles"/>
+      </Feature>
+      <?endif?>
 
       <Feature Id="NodePerfCtrSupport"
                Level="1"
@@ -132,15 +150,22 @@
       </Directory>
 
       <Directory Id="$(var.ProgramFilesFolderId)">
-        <Directory Id="INSTALLDIR" Name="nodejs">
+        <Directory Id='NodejsUwp' Name='NodejsUwp'>
+          <Directory Id='INSTALLDIR' Name='Console'/>
         </Directory>
       </Directory>
     </Directory>
 
     <DirectoryRef Id="INSTALLDIR">
       <Component Id="NodeExecutable">
-        <File Id="node.exe" KeyPath="yes" Source="$(var.SourceDir)\node.exe"/>
+        <File Id="node.exe" KeyPath="yes" Source="$(var.NodeExeSource)"/>
       </Component>
+
+      <?if $(var.NodeEngine) = "chakracore" ?>
+      <Component Id="ChakraCoreDLL">
+        <File Id="chakracore.dll" KeyPath="yes" Source="$(var.SourceDir)\$(var.SdkTargetArch)\chakracore.dll"/>
+      </Component>
+      <?endif?>
 
       <Component Id="NodeRegistryEntries">
         <RegistryValue Root="HKLM"
@@ -188,17 +213,17 @@
                        Value="1"
                        KeyPath="yes"/>
         <Shortcut Id="NodeVarsScriptShortcut"
-                  Name="Node.js command prompt"
+                  Name="$(var.ProductName) command prompt"
                   Target="[%ComSpec]"
                   Arguments='/k "[INSTALLDIR]nodevars.bat"'
                   Show="normal"
                   WorkingDirectory="INSTALLDIR"/>
         <Shortcut Id="NodeExecutableShortcut"
-                  Name="Node.js"
+                  Name="$(var.ProductName)"
                   Target="[INSTALLDIR]node.exe"
                   WorkingDirectory="INSTALLDIR"/>
         <Shortcut Id="UninstallProduct"
-                  Name="Uninstall Node.js"
+                  Name="Uninstall $(var.ProductName)"
                   Target="[SystemFolder]msiexec.exe"
                   Arguments="/x [ProductCode]"/>
         <RemoveFolder Id="RemoveApplicationProgramsFolder"
@@ -327,19 +352,13 @@
       <DialogRef Id="UserExit"/>
       <DialogRef Id="WelcomeDlg"/>
       <DialogRef Id="LicenseAgreementDlg"/>
-      <DialogRef Id="InstallDirDlg"/>
       <DialogRef Id="BrowseDlg"/>
       <DialogRef Id="InvalidDirDlg"/>
 
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1"</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg" Order="20">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="10">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="10">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="20">1</Publish>
+	  <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">LicenseAccepted = "1"</Publish>
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="1">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
@@ -350,7 +369,7 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
       <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
-      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="2">NOT Installed</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" Order="2">NOT Installed</Publish>
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="!(loc.WIXUI_EXITDIALOGOPTIONALTEXT)"/>

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -145,6 +145,11 @@ if "%target_type%"=="uwp-dll" (
 
 if defined config_flags set configure_flags=%configure_flags% %config_flags%
 
+if defined NODE_VERSION_TAG (
+  set DISTTYPE=custom
+  set CUSTOMTAG=%NODE_RELEASE_TAG%%NODE_VERSION_TAG%
+)
+
 if not exist "%~dp0deps\icu" goto no-depsicu
 if "%target%"=="Clean" echo deleting %~dp0deps\icu
 if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu


### PR DESCRIPTION
These are fixes that were meant to be part of previous check-ins but I found through testing today:
* The wix proj for the msi had not been updated to use correct names for node-chakra installer. i.e. path was progamfiles\nodejs instead of programfiles\nodejsuwp\console.
* npm (in configure.js) had not been updated to use an sdk.