### PR TITLE
gyp: Fix issue with building addons

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -331,9 +331,6 @@
                   'advapi32.lib',
                 ],
               },
-              'VCCLCompilerTool': {		
-                'CompileAsWinRT': 'false',		
-              }
             },
           }],
         ],

--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -173,6 +173,11 @@
           'defines': [
             '_WINSOCK_DEPRECATED_NO_WARNINGS'
           ],
+          'msvs_settings': {
+            'VCCLCompilerTool': {		
+              'CompileAsWinRT': 'false',		
+            }
+          },
         }],
       ]
     }

--- a/deps/chakrashim/chakrashim.gyp
+++ b/deps/chakrashim/chakrashim.gyp
@@ -45,6 +45,11 @@
           'libraries': [
             '<@(node_engine_libs)',
           ],
+          'msvs_settings': {
+            'VCCLCompilerTool': {		
+              'CompileAsWinRT': 'false',		
+            }
+          },
         }],
       ],
       'msvs_use_library_dependency_inputs': 1,
@@ -71,6 +76,11 @@
             'libraries': [
               '<@(node_engine_libs)',
             ],
+            'msvs_settings': {
+              'VCCLCompilerTool': {		
+                'CompileAsWinRT': 'false',		
+              }
+            },
           }],
         ],
       },

--- a/deps/http_parser/http_parser.gyp
+++ b/deps/http_parser/http_parser.gyp
@@ -67,7 +67,14 @@
               'CompileAs': 2,
             },
           },
-        }]
+        }],
+        [ 'node_uwp_dll=="true"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {		
+              'CompileAsWinRT': 'false',		
+            }
+          },
+        }],
       ],
     },
 

--- a/deps/logger/logger.gyp
+++ b/deps/logger/logger.gyp
@@ -21,6 +21,13 @@
             'BUILDING_CHAKRASHIM=1',  # other deps don't import chakrashim exports
           ],
         }],
+        [ 'node_uwp_dll=="true"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {		
+              'CompileAsWinRT': 'false',		
+            }
+          },
+        }],
       ],
     },
   ]

--- a/deps/openssl_uwp/openssl.gyp
+++ b/deps/openssl_uwp/openssl.gyp
@@ -169,6 +169,11 @@
           'destination': 'openssl/include/openssl',
           'files': ['<@(openssl_headers)'],
         },],
+        'msvs_settings': {
+          'VCCLCompilerTool': {		
+            'CompileAsWinRT': 'false',		
+          }
+        },
       }],
       ['is_clang==1 or gcc_version>=43', {
         'cflags': ['-Wno-old-style-declaration'],

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -184,6 +184,11 @@
         }],
         ['node_uwp_dll=="true"', {
 		  'sources': [ 'src/win/uwp.cpp' ],
+          'msvs_settings': {
+            'VCCLCompilerTool': {		
+              'CompileAsWinRT': 'false',		
+            }
+          },
         }],
         [ 'OS in "linux mac ios android"', {
           'sources': [ 'src/unix/proctitle.c' ],

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -183,7 +183,7 @@
           ],
         }],
         ['node_uwp_dll=="true"', {
-		  'sources': [ 'src/win/uwp.cpp' ],
+          'sources': [ 'src/win/uwp.cpp' ],
           'msvs_settings': {
             'VCCLCompilerTool': {		
               'CompileAsWinRT': 'false',		

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -61,6 +61,13 @@
                 'USE_FILE32API'
               ],
             }],
+            ['node_uwp_dll=="true"', {
+              'msvs_settings': {
+                'VCCLCompilerTool': {		
+                  'CompileAsWinRT': 'false',		
+                }
+              },
+            }],
           ],
         },
       ],

--- a/node.gyp
+++ b/node.gyp
@@ -544,6 +544,11 @@
               'dependencies': [ 'deps/logger/logger.gyp:logger' ],
               'libraries': [ '-lchakrart' ],
               'msvs_disabled_warnings': [4146],
+              'msvs_settings': {
+                'VCCLCompilerTool': {		
+                  'CompileAsWinRT': 'false',		
+                }
+              },
             }],
           ],
         }, { # POSIX


### PR DESCRIPTION
The issue was a regression caused by duplicate removal from my
previous commits.
CompileAsWinRT needs to be set at the individual project level and
not in common.gypi. If it's defined in common.gypi it overrides the
value set in addon.gypi, and it shouldn't.