### PR TITLE
Fix `GetOwnPropertyNames` and `GetPropertyNames`

### DIFF
--- a/deps/chakrashim/lib/chakra_shim.js
+++ b/deps/chakrashim/lib/chakra_shim.js
@@ -37,7 +37,8 @@
     Set_entries = Set.prototype.entries,
     Set_values = Set.prototype.values,
     Symbol_keyFor = Symbol.keyFor,
-    Symbol_for = Symbol.for;
+    Symbol_for = Symbol.for,
+    Global_ParseInt = parseInt;
   var BuiltInError = Error;
   var global = this;
 
@@ -232,7 +233,7 @@
     function ensureStackTrace() {
       if (!currentStackTrace) {
         currentStackTrace = parseStack(
-          Reflect_apply(oldStackDesc.get, e) || '', // Call saved old getter
+          Reflect_apply(oldStackDesc.get, e, []) || '', // Call saved old getter
           skipDepth, startFuncName);
       }
       return currentStackTrace;
@@ -276,7 +277,7 @@
       Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError,
       URIError
     ].forEach(function(type) {
-      var newType = function __newType() {
+      var newType = function newType() {
         var e = withStackTraceLimitOffset(
           3, () => Reflect_construct(type, arguments, new.target || newType));
         // skip 3 frames: lambda, withStackTraceLimitOffset, this frame
@@ -428,7 +429,7 @@
   var microTasks = [];
 
   function patchUtils(utils) {
-    var isUintRegex = /^(0|[1-9]\\d*)$/;
+    var isUintRegex = /^(0|[1-9]\d*)$/;
 
     var isUint = function(value) {
       var result = isUintRegex.test(value);
@@ -449,7 +450,11 @@
     utils.getPropertyNames = function(a) {
       var names = [];
       for (var propertyName in a) {
-        names.push(propertyName);
+        if (isUint(propertyName)) {
+          names.push(Global_ParseInt(propertyName));
+        } else {
+          names.push(propertyName);
+        }
       }
       return names;
     };
@@ -587,6 +592,22 @@
         attributes |= DontDelete;
       }
       return attributes;
+    };
+    utils.getOwnPropertyNames = function(obj) {
+      var ownPropertyNames = Object_getOwnPropertyNames(obj);
+      var i = 0;
+      while (i < ownPropertyNames.length) {
+        var item = ownPropertyNames[i];
+        if (isUint(item)) {
+          ownPropertyNames[i] = Global_ParseInt(item);
+          i++;
+          continue;
+        }
+        // As per spec, getOwnPropertyNames() first include
+        // numeric properties followed by non-numeric
+        break;
+      }
+      return ownPropertyNames;
     };
   }
 


### PR DESCRIPTION
Applying the fix from https://github.com/nodejs/node-chakracore/commit/971683705594ad7f58039b96ebac48d2b2f78ee3

This fix will resolve the issue reported below:
https://social.msdn.microsoft.com/Forums/en-US/c5188d26-b5c4-459c-8844-5661fb277e0e/nodejsdebugging-the-program-3092-backgroundtaskhostexe-has-exited-with-code-1073741189?forum=WindowsIoT&prof=required

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
